### PR TITLE
[15] [UI] As a logged-in user, I can see the empty repositories preferences screen

### DIFF
--- a/GithubNotifications.xcodeproj/project.pbxproj
+++ b/GithubNotifications.xcodeproj/project.pbxproj
@@ -29,6 +29,10 @@
 		099D0B7B26E78B7400960001 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 099D0B7A26E78B7400960001 /* Constants.swift */; };
 		099D0B7D26E78DB200960001 /* GithubAPIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 099D0B7C26E78DB200960001 /* GithubAPIError.swift */; };
 		099D0B8026E85ACA00960001 /* NimbleExtension in Frameworks */ = {isa = PBXBuildFile; productRef = 099D0B7F26E85ACA00960001 /* NimbleExtension */; };
+		9001258626E9E9B500C2643C /* RepositoryScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9001258526E9E9B500C2643C /* RepositoryScreen.swift */; };
+		9001258F26E9F26000C2643C /* Color+Hex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9001258E26E9F26000C2643C /* Color+Hex.swift */; };
+		9001259326E9FB8900C2643C /* View+Border.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9001259226E9FB8900C2643C /* View+Border.swift */; };
+		900125B226EA058300C2643C /* RoundedButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 900125B126EA058300C2643C /* RoundedButtonStyle.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -75,6 +79,10 @@
 		099D0B4C26E78A2B00960001 /* DecoderFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DecoderFactory.swift; sourceTree = "<group>"; };
 		099D0B7A26E78B7400960001 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		099D0B7C26E78DB200960001 /* GithubAPIError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GithubAPIError.swift; sourceTree = "<group>"; };
+		9001258526E9E9B500C2643C /* RepositoryScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryScreen.swift; sourceTree = "<group>"; };
+		9001258E26E9F26000C2643C /* Color+Hex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+Hex.swift"; sourceTree = "<group>"; };
+		9001259226E9FB8900C2643C /* View+Border.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Border.swift"; sourceTree = "<group>"; };
+		900125B126EA058300C2643C /* RoundedButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundedButtonStyle.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -165,8 +173,11 @@
 			isa = PBXGroup;
 			children = (
 				099D0B3026E787B200960001 /* Application */,
+				9001258C26E9F24600C2643C /* Extensions */,
+				9001258B26E9F00F00C2643C /* Models */,
 				099D0B3126E787C400960001 /* Module */,
 				099D0B3626E789FE00960001 /* Services */,
+				9001258726E9EFD300C2643C /* Views */,
 			);
 			path = Source;
 			sourceTree = "<group>";
@@ -203,6 +214,7 @@
 		099D0B3126E787C400960001 /* Module */ = {
 			isa = PBXGroup;
 			children = (
+				9001258426E9E98000C2643C /* Repository */,
 				099D0AFA26E783EC00960001 /* ContentView.swift */,
 			);
 			path = Module;
@@ -253,7 +265,6 @@
 			children = (
 				099D0B3826E78A2B00960001 /* API */,
 				099D0B4A26E78A2B00960001 /* Factory */,
-				099D0B4D26E78A2B00960001 /* Services */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -290,19 +301,52 @@
 			path = Factory;
 			sourceTree = "<group>";
 		};
-		099D0B4D26E78A2B00960001 /* Services */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Services;
-			sourceTree = "<group>";
-		};
 		099D0B7926E78B6200960001 /* Constants */ = {
 			isa = PBXGroup;
 			children = (
 				099D0B7A26E78B7400960001 /* Constants.swift */,
 			);
 			path = Constants;
+			sourceTree = "<group>";
+		};
+		9001258426E9E98000C2643C /* Repository */ = {
+			isa = PBXGroup;
+			children = (
+				9001258526E9E9B500C2643C /* RepositoryScreen.swift */,
+			);
+			path = Repository;
+			sourceTree = "<group>";
+		};
+		9001258726E9EFD300C2643C /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				900125B026EA057400C2643C /* Buttons */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
+		9001258B26E9F00F00C2643C /* Models */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
+		9001258C26E9F24600C2643C /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				9001258E26E9F26000C2643C /* Color+Hex.swift */,
+				9001259226E9FB8900C2643C /* View+Border.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
+		900125B026EA057400C2643C /* Buttons */ = {
+			isa = PBXGroup;
+			children = (
+				900125B126EA058300C2643C /* RoundedButtonStyle.swift */,
+			);
+			path = Buttons;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -446,8 +490,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9001258F26E9F26000C2643C /* Color+Hex.swift in Sources */,
 				099D0B6726E78A2B00960001 /* Request.swift in Sources */,
 				099D0B6526E78A2B00960001 /* Network+Typealias.swift in Sources */,
+				900125B226EA058300C2643C /* RoundedButtonStyle.swift in Sources */,
 				099D0AF726E783EC00960001 /* AppDelegate.swift in Sources */,
 				099D0B6B26E78A2B00960001 /* DecoderFactory.swift in Sources */,
 				099D0B6626E78A2B00960001 /* BaseModels.swift in Sources */,
@@ -460,6 +506,8 @@
 				099D0B6826E78A2B00960001 /* API.swift in Sources */,
 				099D0AFB26E783EC00960001 /* ContentView.swift in Sources */,
 				099D0B7D26E78DB200960001 /* GithubAPIError.swift in Sources */,
+				9001259326E9FB8900C2643C /* View+Border.swift in Sources */,
+				9001258626E9E9B500C2643C /* RepositoryScreen.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -643,6 +691,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = co.nimblehq.GithubNotifications;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTS_MACCATALYST = YES;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "2,6";
 			};
@@ -670,6 +719,7 @@
 				"PRODUCT_BUNDLE_IDENTIFIER[sdk=macosx*]" = co.nimblehq.GithubNotifications;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTS_MACCATALYST = YES;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "2,6";
 			};

--- a/Source/Application/Constants/Constants.swift
+++ b/Source/Application/Constants/Constants.swift
@@ -14,4 +14,6 @@ enum Constants {
 
         static let baseURLPath = "https://api.github.com/notifications"
     }
+
+    enum Color { }
 }

--- a/Source/Application/SceneDelegate/SceneDelegate.swift
+++ b/Source/Application/SceneDelegate/SceneDelegate.swift
@@ -24,7 +24,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // Use a UIHostingController as window root view controller.
         if let windowScene = scene as? UIWindowScene {
             let window = UIWindow(windowScene: windowScene)
-            window.rootViewController = UIHostingController(rootView: contentView)
+            window.rootViewController = UIHostingController(
+                rootView: contentView.environment(\.colorScheme, .light)
+            )
             self.window = window
             window.makeKeyAndVisible()
         }

--- a/Source/Extensions/Color+Hex.swift
+++ b/Source/Extensions/Color+Hex.swift
@@ -1,0 +1,26 @@
+//
+//  Color+Hex.swift
+//  GithubNotifications
+//
+//  Created by Su T. Nguyen on 09/09/2021.
+//  Copyright © 2021 Nimblehq. All rights reserved.
+//
+
+import SwiftUI
+
+extension Color {
+
+    static let border = Color(hex: 0xECECEC)
+    static let brightGray = Color(hex: 0x797979)
+    static let almostBlack = Color(hex: 0x232526)
+
+    init(hex: Int) {
+        self.init(
+            .sRGB,
+            red: Double((hex >> 16) & 0xff) / 255,
+            green: Double((hex >> 08) & 0xff) / 255,
+            blue: Double((hex >> 00) & 0xff) / 255,
+            opacity: 1.0
+        )
+    }
+}

--- a/Source/Extensions/View+Border.swift
+++ b/Source/Extensions/View+Border.swift
@@ -1,0 +1,23 @@
+//
+//  View+Overlay.swift
+//  GithubNotifications
+//
+//  Created by Su T. Nguyen on 09/09/2021.
+//  Copyright © 2021 Nimblehq. All rights reserved.
+//
+
+import SwiftUI
+
+extension View {
+
+    func border(
+        _ color: Color = .black,
+        width: CGFloat = 0.0,
+        radius: CGFloat = 0.0
+    ) -> some View {
+        overlay(
+            RoundedRectangle(cornerRadius: radius)
+                .stroke(color, lineWidth: width)
+        )
+    }
+}

--- a/Source/Module/ContentView.swift
+++ b/Source/Module/ContentView.swift
@@ -8,9 +8,9 @@
 import SwiftUI
 
 struct ContentView: View {
+
     var body: some View {
-        Text("Hello, world!")
-            .padding()
+        RepositoryScreen()
     }
 }
 

--- a/Source/Module/Repository/RepositoryScreen.swift
+++ b/Source/Module/Repository/RepositoryScreen.swift
@@ -1,0 +1,79 @@
+//
+//  RepositoryScreen.swift
+//  GithubNotifications
+//
+//  Created by Su T. Nguyen on 09/09/2021.
+//  Copyright © 2021 Nimblehq. All rights reserved.
+//
+
+import SwiftUI
+
+struct RepositoryScreen: View {
+
+    var body: some View {
+        NavigationView {
+            NavigationView { }
+                .navigationTitle("Preferences")
+
+            makeRepoListView()
+                .padding()
+        }
+    }
+
+    private func makeRepoListView() -> some View {
+        VStack(alignment: .leading) {
+            Text("You will receive all notifications of these repositories.")
+                .paddingLeft8()
+                .foregroundColor(.brightGray)
+
+            List { }
+            .border(.border, width: 1.0, radius: 8.0)
+            .paddingLeft8()
+
+            HStack {
+                Spacer()
+                makeAddButton()
+                    .padding(.top, 18.0)
+                    .padding(.bottom, 22.0)
+                Spacer()
+            }
+
+        }
+        .navigationTitle("Repositories")
+        .foregroundColor(.almostBlack)
+    }
+}
+
+extension View {
+}
+
+// MARK: - Private
+
+extension View {
+
+    func makeAddButton() -> some View {
+        Button {
+            print("Add new did tap")
+        } label: {
+            Text("Add New")
+                .frame(maxWidth: 160.0, maxHeight: 18.0)
+        }
+        .buttonStyle(
+            RoundedButtonStyle(
+                foregroundColor: .white,
+                backgroundColor: .almostBlack,
+                pressedColor: .border
+            )
+        )
+    }
+
+    fileprivate func paddingLeft8() -> some View {
+        padding(.leading, 8.0)
+    }
+}
+
+struct RepositoryScreen_Previews: PreviewProvider {
+    static var previews: some View {
+        RepositoryScreen()
+    }
+}

--- a/Source/Module/Repository/RepositoryScreen.swift
+++ b/Source/Module/Repository/RepositoryScreen.swift
@@ -62,7 +62,7 @@ extension View {
             RoundedButtonStyle(
                 foregroundColor: .white,
                 backgroundColor: .almostBlack,
-                pressedColor: .border
+                pressedColor: .almostBlack.opacity(0.5)
             )
         )
     }

--- a/Source/Module/Repository/RepositoryScreen.swift
+++ b/Source/Module/Repository/RepositoryScreen.swift
@@ -33,8 +33,6 @@ struct RepositoryScreen: View {
             HStack {
                 Spacer()
                 makeAddButton()
-                    .padding(.top, 18.0)
-                    .padding(.bottom, 22.0)
                 Spacer()
             }
 
@@ -65,6 +63,8 @@ extension View {
                 pressedColor: .almostBlack.opacity(0.5)
             )
         )
+        .padding(.top, 18.0)
+        .padding(.bottom, 22.0)
     }
 
     fileprivate func paddingLeft8() -> some View {

--- a/Source/Views/Buttons/RoundedButtonStyle.swift
+++ b/Source/Views/Buttons/RoundedButtonStyle.swift
@@ -1,0 +1,24 @@
+//
+//  RoundedButton.swift
+//  GithubNotifications
+//
+//  Created by Su T. Nguyen on 09/09/2021.
+//  Copyright © 2021 Nimblehq. All rights reserved.
+//
+
+import SwiftUI
+
+struct RoundedButtonStyle: ButtonStyle {
+
+    var foregroundColor: Color
+    var backgroundColor: Color
+    var pressedColor: Color
+
+    func makeBody(configuration: Self.Configuration) -> some View {
+        configuration.label
+            .padding(10.0)
+            .foregroundColor(foregroundColor)
+            .background(configuration.isPressed ? pressedColor : backgroundColor)
+            .cornerRadius(6.0)
+    }
+}


### PR DESCRIPTION
resolve #15

## What happened 👀

To support the logged-in user to select repositories they want for notifications, we need to create a repositories preferences screen
 
## Insight 📝

- Create empty List of repository
- Create button `Add New`

 
## Proof Of Work 📹

![Screen Shot 2021-09-09 at 16 57 28](https://user-images.githubusercontent.com/17830319/132665896-bb517f5e-a282-44ba-b2c8-7d1115ba91ad.png)

Force to use light mode:
![Screen Shot 2021-09-09 at 17 21 03](https://user-images.githubusercontent.com/17830319/132669026-cc6a15b6-3375-451d-be05-aefd92316d1f.png)
