### PR TITLE
[CI] Fix fastlane match by adding readonly

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,34 @@
+name: test
+
+on:
+  push:
+    branches: [ chore/**, feature/**, bug/**]
+
+jobs:
+        
+  Test:
+    name: Test
+    runs-on: macos-11
+    steps:
+    - name: Cancel Previous Runs
+      uses: styfle/cancel-workflow-action@0.5.0
+      with:
+        access_token: ${{ github.token }}
+
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+            
+    - name: Bundle install
+      run: bundle install
+
+    - name: Cache SPM
+      uses: actions/cache@v2
+      with:
+        path: .build
+        key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
+        restore-keys: |
+          ${{ runner.os }}-spm-
+
+    - name: Test Build
+      run: bundle exec fastlane scan_build

--- a/fastlane/fastfile
+++ b/fastlane/fastfile
@@ -36,7 +36,8 @@ platform :mac do
       team_id: ENV['TEAM_ID'],
       keychain_name: keychain_name,
       keychain_password: keychain_password,
-      app_identifier: ""
+      app_identifier: "",
+      readonly: true
     )
   end
 

--- a/fastlane/fastfile
+++ b/fastlane/fastfile
@@ -61,4 +61,13 @@ platform :mac do
       output_path: "GithubNotifications.app.zip"
     )
   end
+
+  desc 'Test Build'
+  lane :scan_build do
+    build_mac_app(
+      configuration: 'Debug',
+      skip_codesigning:true,
+      skip_archive:true
+    )
+  end
 end


### PR DESCRIPTION
Fix CI is failing because match.

Add a Workflow to scan build when push.

<img width="516" alt="Screen Shot 2021-09-10 at 12 13 56" src="https://user-images.githubusercontent.com/6356137/132803193-dcb601d3-564f-40e2-9e12-c1a55ec8b3fa.png">

<img width="744" alt="Screen Shot 2021-09-10 at 12 25 28" src="https://user-images.githubusercontent.com/6356137/132804031-f099ac2e-3fe4-4d17-9004-1e45ea940bf5.png">
