### PR TITLE
[Chore] Add bump tag workflow

### DIFF
--- a/.github/workflows/bump_tag.yml
+++ b/.github/workflows/bump_tag.yml
@@ -1,0 +1,19 @@
+name: Bump version
+
+on:
+  push:
+    branches:
+      - main
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check Out
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: '0'
+    - name: Bump version and push tag
+      uses: anothrNick/github-tag-action@1.36.0
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        WITH_V: true


### PR DESCRIPTION
Add bump tag workflow when merge to main so that CI create a minor release. More on [bump flexibility](https://github.com/anothrNick/github-tag-action#workflow)