### PR TITLE
[66] [Bug] [Backend] As a Github User with no email in user object, I would like to be able to log in

### DIFF
--- a/Source/Models/APIModels/APIUser.swift
+++ b/Source/Models/APIModels/APIUser.swift
@@ -12,6 +12,6 @@ struct APIUser: Decodable {
 
     let login: String
     let htmlUrl: String
-    let name: String
-    let email: String
+    let name: String?
+    let email: String?
 }


### PR DESCRIPTION
#66 

## What happened 👀

- Update `APIUser`
 
## Insight 📝

- set `email` and `name` properties of `user model to optional.
 
## Proof Of Work 📹

```
---------------------
200 'https://api.github.com/user' [0.8211 s]:
Headers: [
  Etag: W/"bc78a6855ceb2981000f3f5a703998b4fce7bbac0d48696b5f41ec19f3a15bfa"
  x-ratelimit-limit: 5000
  x-accepted-oauth-scopes: 
  x-github-request-id: CBAA:4A83:A43F:3823D:61446643
  Cache-Control: private, max-age=60, s-maxage=60
  x-ratelimit-reset: 1631875354
  Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding, Accept, X-Requested-With
  Last-Modified: Fri, 17 Sep 2021 09:54:55 GMT
  Content-Type: application/json; charset=utf-8
  referrer-policy: origin-when-cross-origin, strict-origin-when-cross-origin
  x-ratelimit-used: 5
  access-control-expose-headers: ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, Deprecation, Sunset
  x-xss-protection: 0
  x-ratelimit-resource: core
  Access-Control-Allow-Origin: *
  x-content-type-options: nosniff
  Date: Fri, 17 Sep 2021 09:56:19 GMT
  x-frame-options: deny
  Server: GitHub.com
  x-oauth-scopes: notifications
  Content-Encoding: gzip
  content-security-policy: default-src 'none'
  github-authentication-token-expiration: 2021-10-17 09:55:30 UTC
  x-github-media-type: github.v3; format=json
  x-ratelimit-remaining: 4995
  Strict-Transport-Security: max-age=31536000; includeSubdomains; preload
]
Body:
{
  "location" : "Bangkok, Thailand",
  "hireable" : null,
  "public_gists" : 5,
  "url" : "https:\/\/api.github.com\/users\/llleyelll",
  "following_url" : "https:\/\/api.github.com\/users\/llleyelll\/following{\/other_user}",
  "events_url" : "https:\/\/api.github.com\/users\/llleyelll\/events{\/privacy}",
  "received_events_url" : "https:\/\/api.github.com\/users\/llleyelll\/received_events",
  "company" : "Kasetsart University",
  "updated_at" : "2021-09-17T09:54:55Z",
  "twitter_username" : null,
  "bio" : "I love trackpad 🤪",
  "avatar_url" : "https:\/\/avatars.githubusercontent.com\/u\/45258998?v=4",
  "name" : null,
  "type" : "User",
  "subscriptions_url" : "https:\/\/api.github.com\/users\/llleyelll\/subscriptions",
  "gists_url" : "https:\/\/api.github.com\/users\/llleyelll\/gists{\/gist_id}",
  "id" : 45258998,
  "starred_url" : "https:\/\/api.github.com\/users\/llleyelll\/starred{\/owner}{\/repo}",
  "organizations_url" : "https:\/\/api.github.com\/users\/llleyelll\/orgs",
  "repos_url" : "https:\/\/api.github.com\/users\/llleyelll\/repos",
  "site_admin" : false,
  "email" : null,
  "login" : "llleyelll",
  "blog" : "llleyelll.github.io",
  "public_repos" : 27,
  "followers" : 19,
  "following" : 22,
  "created_at" : "2018-11-22T10:06:38Z",
  "node_id" : "MDQ6VXNlcjQ1MjU4OTk4",
  "gravatar_id" : "",
  "followers_url" : "https:\/\/api.github.com\/users\/llleyelll\/followers",
  "html_url" : "https:\/\/github.com\/llleyelll"
}
```
