### PR TITLE
[#44] [Integrate] As a logged-in user, I can fetch notification every one minute

### DIFF
--- a/Source/Services/Network/RequestConfigurations/NotificationRequestConfiguration.swift
+++ b/Source/Services/Network/RequestConfigurations/NotificationRequestConfiguration.swift
@@ -44,7 +44,7 @@ extension NotificationRequestConfiguration: RequestConfiguration {
     }
 
     var headers: HTTPHeaders? {
-        return nil
+        return ["If-None-Match": "-"]
     }
 
     var interceptor: RequestInterceptor? {


### PR DESCRIPTION
close #44

## What happened 👀

Notification polling to cache correctly.

## Insight 📝

Github is sending back `W/""` as Etag when 304 and Alamofire does not know how to handle.

Override "If-None-Match" (Etag) from Github with null value.

 
<img width="522" alt="Screen Shot 2021-09-21 at 16 57 39" src="https://user-images.githubusercontent.com/6356137/134152658-7e15d6c1-d52a-4c24-9c01-66c8d2a33cef.png">

## Proof Of Work 📹

Notice some 200 and 304.

<img width="1032" alt="Screen Shot 2021-09-21 at 17 06 48" src="https://user-images.githubusercontent.com/6356137/134152782-82976994-2afa-4970-b1ac-303bd40671cf.png">