### PR TITLE
[#82] Add filter for older notifications

### DIFF
--- a/Source/Extensions/AppStorage+Key.swift
+++ b/Source/Extensions/AppStorage+Key.swift
@@ -14,6 +14,7 @@ extension AppStorage {
         case notificationHasSound
         case repeatPullRequestNotification
         case notifiedRepositories
+        case latestNotificationDate
 
         func callAsFunction() -> String {
             self.rawValue


### PR DESCRIPTION
close #82 

## What happened 👀

Currently when 304 is returned for /notifications, the application will map value from cache. We would like to not map anything when no response is returned in this case.
 
## Insight 📝

Keep a value `latestNotificationDate` from latest notification. Use `latestNotificationDate` to filter new notification. 

No API layer modification.

## Proof Of Work 📹

Debugged by adding a print to each notification, the date will be sorted and only new notification after the latest date will be received by PollManager.

<img width="1050" alt="Screen Shot 2021-09-22 at 18 18 03" src="https://user-images.githubusercontent.com/6356137/134336459-1c8adb1b-8449-4022-a064-0520973755c0.png">
 

<img width="829" alt="Screen Shot 2021-09-22 at 18 17 55" src="https://user-images.githubusercontent.com/6356137/134336448-c15c70f3-113a-4c78-9576-ad66471da2d8.png">