### PR TITLE
[#11] [Integrate] As a logged-in user, I can see the general preferences screen

### DIFF
--- a/Source/Utilities/NotificationManager.swift
+++ b/Source/Utilities/NotificationManager.swift
@@ -68,7 +68,7 @@ final class NotificationManager: NSObject {
                 "url": url
             ]
             
-            let uuid = "\(repoName)\(prTitle)"
+            let uuid = "\(reason.hashValue)\(repoName)\(prTitle)"
             let request = UNNotificationRequest(identifier: uuid, content: content, trigger: nil)
 
             notificationCenter.add(request)


### PR DESCRIPTION
close #11 

## What happened 👀

Notification repeat switch works.
 
## Insight 📝

When showing notification, add another notification after a set period of time to not cancel the current notification.

When user tap the notification, cancel existing notifications with the same ID.
 
## Proof Of Work 📹

Notification in queue 
<img width="418" alt="Screen Shot 2021-09-23 at 16 39 42" src="https://user-images.githubusercontent.com/6356137/134487370-73834ecc-5a4b-4e12-9465-32bea2443c6c.png">
