### PR TITLE
[#77] [Bug] When scrolling Search Repo list, sometimes the scroll view freezes. #77

### DIFF
--- a/Source/Module/SearchRepository/Views/SearchBar.swift
+++ b/Source/Module/SearchRepository/Views/SearchBar.swift
@@ -15,51 +15,50 @@ struct SearchBar: View {
     @State private var isEditing = false
 
     var body: some View {
-        HStack {
+        ZStack {
             TextField(placeholder, text: $text)
                 .disableAutocorrection(true)
                 .padding(.vertical, 8.0)
                 .padding(.leading, 30.0)
                 .padding(.trailing, 25.0)
                 .cornerRadius(8)
-                .overlay(
-                    HStack {
-                        Image(systemName: "magnifyingglass")
-                            .foregroundColor(.gray)
-                            .frame(minWidth: 0.0, maxWidth: .infinity, alignment: .leading)
-                            .padding(.leading, 8.0)
-                            .padding(.top, -1.0)
-
-                        if isEditing {
-                            Button(action: {
-                                self.text = ""
-                            }) {
-                                Image(systemName: "multiply.circle.fill")
-                                    .foregroundColor(.gray)
-                                    .padding(.trailing, 8)
-                            }
+            HStack {
+                Image(systemName: "magnifyingglass")
+                    .foregroundColor(.gray)
+                    .padding(.leading, 8.0)
+                    .padding(.top, -1.0)
+                Spacer()
+                if isEditing {
+                    HStack(spacing: 8.0) {
+                        Button(action: {
+                            self.isEditing = false
+                            self.text = ""
+                            UIApplication.shared.sendAction(
+                                #selector(UIResponder.resignFirstResponder),
+                                to: nil, from: nil, for: nil
+                            )
+                        }) {
+                            Text("Cancel")
+                                .foregroundColor(.white)
                         }
-                    })
-                .onTapGesture {
-                    self.isEditing = true
-                }
+                        .padding(.trailing, 8.0)
+                        .transition(.opacity)
+                        .animation(.easeInOut)
 
-            if isEditing {
-                Button(action: {
-                    self.isEditing = false
-                    self.text = ""
-                    UIApplication.shared.sendAction(
-                        #selector(UIResponder.resignFirstResponder),
-                        to: nil, from: nil, for: nil
-                    )
-                }) {
-                    Text("Cancel")
-                        .foregroundColor(.white)
+                        Button(action: {
+                            self.text = ""
+                        }) {
+                            Image(systemName: "multiply.circle.fill")
+                                .foregroundColor(.gray)
+                        }
+                    }
+                    .padding(.trailing, 8)
                 }
-                .padding(.trailing, 8.0)
-                .transition(.opacity)
-                .animation(.easeInOut)
             }
         }
+        // comment to fix scrollview freezing when searching
+//        .onTapGesture {
+//            self.isEditing = true
+//        }
     }
 }


### PR DESCRIPTION
#77 

## What happened 👀

Fix search scroll freeze.
 
## Insight 📝

Somehow macOS Catalyst doesn't like button on top of Textfield.

https://user-images.githubusercontent.com/6356137/134500238-3b93ab7b-8b3f-4130-974d-5e36fa635c97.mp4



Refactor SeachTextField to use ZStack.

## Proof Of Work 📹

