### PR TITLE
[#94] [Chore] Fix Zip Logic in CI

### DIFF
--- a/fastlane/fastfile
+++ b/fastlane/fastfile
@@ -56,7 +56,11 @@ platform :mac do
 
   desc 'zip app'
   lane :package_app do
-    sh('zip -r ../GithubNotifications.app.zip ../Github\ Notifications.app')
+    sh('mv ../Github\ Notifications.app ../GithubNotifications.app')
+    zip(
+      path: "GithubNotifications.app",
+      output_path: "GithubNotifications.app.zip"
+    )
   end
 
   desc 'Test Build'


### PR DESCRIPTION
close #94 

## What happened 👀

Fix CI package zip.
 
## Insight 📝

Use fastlane `zip` command to package release by renaming the app first.
- fastlane cannot zip file with space in the name
- using sh zip command override write access so people cannot open them.
 
## Proof Of Work 📹


https://nimble-co.slack.com/archives/C029UCS3LKZ/p1632455632011300?thread_ts=1632398017.010700&cid=C029UCS3LKZ