### PR TITLE
[#100] [Bug] Notification Subject Type doesn't handle correctly

### DIFF
--- a/GithubNotifications.xcodeproj/project.pbxproj
+++ b/GithubNotifications.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		09D7774F26EF38E700417BD1 /* NetworkPoll.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09D7774E26EF38E700417BD1 /* NetworkPoll.swift */; };
 		2D4ED7E526F9B90000EA94D6 /* AccountViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D4ED7E426F9B90000EA94D6 /* AccountViewModel.swift */; };
 		2DCC7E3226F98ABA00367CEC /* AccountScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DCC7E3126F98ABA00367CEC /* AccountScreen.swift */; };
+		84402A6426FD8BB80062A569 /* String+CamelCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84402A6326FD8BB80062A569 /* String+CamelCase.swift */; };
 		8450FC4026FAF8DB00DD4C84 /* UNUserNotificationCenter+Future.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8450FC3F26FAF8DB00DD4C84 /* UNUserNotificationCenter+Future.swift */; };
 		8458AF7B26E8731F009F1B9B /* LoginScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8458AF7A26E8731F009F1B9B /* LoginScreen.swift */; };
 		846BCE4026F0808800FD9B39 /* ContentViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 846BCE3F26F0808800FD9B39 /* ContentViewModel.swift */; };
@@ -132,6 +133,7 @@
 		09D7774E26EF38E700417BD1 /* NetworkPoll.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkPoll.swift; sourceTree = "<group>"; };
 		2D4ED7E426F9B90000EA94D6 /* AccountViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountViewModel.swift; sourceTree = "<group>"; };
 		2DCC7E3126F98ABA00367CEC /* AccountScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountScreen.swift; sourceTree = "<group>"; };
+		84402A6326FD8BB80062A569 /* String+CamelCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+CamelCase.swift"; sourceTree = "<group>"; };
 		8450FC3F26FAF8DB00DD4C84 /* UNUserNotificationCenter+Future.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UNUserNotificationCenter+Future.swift"; sourceTree = "<group>"; };
 		8458AF7A26E8731F009F1B9B /* LoginScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginScreen.swift; sourceTree = "<group>"; };
 		846BCE3F26F0808800FD9B39 /* ContentViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentViewModel.swift; sourceTree = "<group>"; };
@@ -550,6 +552,7 @@
 				9001259226E9FB8900C2643C /* View+Border.swift */,
 				8486472A26F25E2300E431BD /* Array+RawRepresentable.swift */,
 				8450FC3F26FAF8DB00DD4C84 /* UNUserNotificationCenter+Future.swift */,
+				84402A6326FD8BB80062A569 /* String+CamelCase.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -771,6 +774,7 @@
 				0902827726EB29270010F02E /* NotificationRequestConfiguration.swift in Sources */,
 				099D0B7B26E78B7400960001 /* Constants.swift in Sources */,
 				84C9E91526E9D18F00B56DD4 /* TextLabelWithHyperLink.swift in Sources */,
+				84402A6426FD8BB80062A569 /* String+CamelCase.swift in Sources */,
 				90DC331326F87DD600515E83 /* RepositoryRequestConfiguration.swift in Sources */,
 				900125B626EA18AD00C2643C /* SearchRepoScreen.swift in Sources */,
 				84F436DF26FA3F0D00029B85 /* NotificationManager.swift in Sources */,

--- a/Source/Extensions/String+CamelCase.swift
+++ b/Source/Extensions/String+CamelCase.swift
@@ -21,7 +21,7 @@ extension String {
     var camelized: String {
         guard !isEmpty else { return "" }
         let parts = components(separatedBy: CharacterSet.alphanumerics.inverted)
-        let first = String(describing: parts.first!).lowercasingFirst
+        let first = String(describing: parts.first ?? "").lowercasingFirst
         let rest = parts.dropFirst().map({String($0).uppercasingFirst})
         return ([first] + rest).joined(separator: "")
     }

--- a/Source/Extensions/String+CamelCase.swift
+++ b/Source/Extensions/String+CamelCase.swift
@@ -1,0 +1,28 @@
+//
+//  String+CamelCase.swift
+//  Github Notifications
+//
+//  Created by Chananchida F. on 9/24/21.
+//  Copyright © 2021 Nimblehq. All rights reserved.
+//
+
+import Foundation
+
+extension String {
+
+    var uppercasingFirst: String {
+        return prefix(1).uppercased() + dropFirst()
+    }
+
+    var lowercasingFirst: String {
+        return prefix(1).lowercased() + dropFirst()
+    }
+
+    var camelized: String {
+        guard !isEmpty else { return "" }
+        let parts = components(separatedBy: CharacterSet.alphanumerics.inverted)
+        let first = String(describing: parts.first!).lowercasingFirst
+        let rest = parts.dropFirst().map({String($0).uppercasingFirst})
+        return ([first] + rest).joined(separator: "")
+    }
+}

--- a/Source/Models/APIModels/NotificationSubjectType.swift
+++ b/Source/Models/APIModels/NotificationSubjectType.swift
@@ -17,7 +17,7 @@ enum NotificationSubjectType: String, Decodable {
 
     init(from decoder: Decoder) throws {
         let value = try decoder.singleValueContainer().decode(String.self)
-        let decoded = NotificationSubjectType(rawValue: value.capitalized)
+        let decoded = NotificationSubjectType(rawValue: value.camelized)
         self = decoded ?? .unknown
     }
 }


### PR DESCRIPTION
Resolves #100 

## What happened 👀

- Update `NotificationSubjectType` mapping logic 
 
## Insight 📝

- Add String extension for camel case
 
## Proof Of Work 📹
![Screen Shot 2021-09-24 at 12 01 31 PM](https://user-images.githubusercontent.com/45258998/134620890-6cdb39af-ec3d-4989-9e51-df7805eb3ac1.png)


