### PR TITLE
[#99] [Integrate] As a logged-in user, when I press on the review request notification banner, in case I enable the option repeat review requested notification, I don't want to show that banner again

### DIFF
--- a/Source/Utilities/NotificationManager.swift
+++ b/Source/Utilities/NotificationManager.swift
@@ -137,7 +137,6 @@ extension NotificationManager: UNUserNotificationCenterDelegate {
     func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
         switch response.actionIdentifier {
         case UNNotificationDefaultActionIdentifier:
-            notificationCenter.removePendingNotificationRequests(withIdentifiers: [response.notification.request.identifier])
             guard let stringURL = response
                     .notification
                     .request
@@ -147,7 +146,7 @@ extension NotificationManager: UNUserNotificationCenterDelegate {
             UIApplication.shared.open(url)
         default: break
         }
-
+        notificationCenter.removePendingNotificationRequests(withIdentifiers: [response.notification.request.identifier])
         completionHandler()
     }
 }


### PR DESCRIPTION
close #99 

## What happened 👀

User can stop repeating notification by opening one.
 
## Insight 📝

Move remove notification logic for all notification type and after opening link.
 
## Proof Of Work 📹

<img width="374" alt="Screen Shot 2021-09-24 at 12 57 02" src="https://user-images.githubusercontent.com/6356137/134625855-3857634f-2b3f-4e40-aaef-ffd7c39f1a9d.png">

